### PR TITLE
Switch from `drush` and `wp-cli` to `cv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,18 @@ be used for testing upgrade-logic.
 ### Scope
 
 To facilitate testing of many databases, the current script uses the
-command-line based upgrade system (drush) and never uses the web-based UI
-(civicrm/upgrade).  Therefore, it is appropriate for testing the database
+command-line-based upgrader (`cv upgrade:db`) and never uses the web-based UI
+(`civicrm/upgrade`).  Therefore, it is appropriate for testing the database
 manipulations. It does not currently test for:
 
- * Issues in the upgrader web UI (such as browser compatibility)
- * Issues with different CMS's (Joomla, WordPress, Drupal 6)
+ * Issues in the web UI (such as browser compatibility or CMS page-loading)
  * Issues in the civicrm.settings.php
  * Issues with setup or compatibility of PHP, MySQL, etc
 
 ### Pre-Requisites
 
  * Have a Unix-like environment (bash)
- * Install CiviCRM and either Drupal+Drush or WordPress+WP CLI.
+ * Install CiviCRM and cv
  * Configure the username/password for a MySQL administrator in  ~/.my.cnf 
 
 ### Setup

--- a/civicrm-upgrade-test
+++ b/civicrm-upgrade-test
@@ -68,12 +68,13 @@ function drop_civicrm_sql {
 function check_error {
   OUTPUT="$1"
   LOG="$2"
-  ## Checkout OUTPUT
-  if head -n1 "$OUTPUT" | grep '^Upgrade output' > /dev/null ; then
-    ## Check log
-    if grep '\[info\] $backTrace' "$LOG" > /dev/null ; then
-      echo 1
-    fi
+  ## Checkout OUTPUT and LOG
+  if grep '\[\(error\|warning\)\]' "$LOG" > /dev/null ; then
+    echo 1
+    return
+  fi
+  if tail -n1 "$OUTPUT" | grep '^Have a nice day' > /dev/null ; then
+    echo
   else
     echo 1
   fi
@@ -163,27 +164,15 @@ fi
 
 #####################################################################
 ## Run upgrades
-if [ -n "$DRUPAL_SITE" ]; then
-  DRUSH="drush -l $DRUPAL_SITE"
-else
-  DRUSH="drush"
-fi
+
+set -e
+LOGPAT=$( cv --cwd="$WEB_ROOT" path -c 'configAndLogDir/CiviCRM.*.log' )
+set +e
 
 for SQLBZ2 in $DATABASE_FILES ; do
   NAME=$(basename $SQLBZ2)
   OUTPUT="${OUTPUT_DIR}/${NAME}.out"
   LOG="${OUTPUT_DIR}/${NAME}.log"
-  if grep backdrop "$WEB_ROOT/index.php" ; then
-    LOGPAT="$WEB_ROOT/files/civicrm/ConfigAndLog/CiviCRM.*.log"
-  elif [ -f "$WEB_ROOT/wp-config.php" ] ; then
-    LOGPAT="$WEB_ROOT/wp-content/uploads/civicrm/ConfigAndLog/CiviCRM.*.log"
-  else
-    if [ -z "$DRUPAL_SITE" ]; then
-      LOGPAT="$WEB_ROOT/sites/default/files/civicrm/ConfigAndLog/CiviCRM.*.log"
-    else
-      LOGPAT="$WEB_ROOT/sites/$DRUPAL_SITE/files/civicrm/ConfigAndLog/CiviCRM.*.log"
-    fi
-  fi
 
   echo ""
   echo "------------------------------------------------------"
@@ -205,11 +194,7 @@ for SQLBZ2 in $DATABASE_FILES ; do
   pushd "$WEB_ROOT" > /dev/null
   rm -f $LOGPAT
   echo; echo "Upgrading database $TEST_DATABASE"
-  if [ -f "$WEB_ROOT/wp-config.php" ] ; then
-    wp civicrm upgrade-db > "$OUTPUT" 2>&1
-  else
-    $DRUSH civicrm-upgrade-db > "$OUTPUT" 2>&1
-  fi
+  cv upgrade:db -vv --no-interaction > "$OUTPUT" 2>&1
   echo "LOGPAT: $LOGPAT" > $LOG
   cat $LOGPAT >> $LOG
   popd > /dev/null

--- a/civicrm-upgrade-test.settings.txt
+++ b/civicrm-upgrade-test.settings.txt
@@ -1,13 +1,6 @@
 ## The base directory of the Drupal-Civi test installation.
 WEB_ROOT=/Applications/MAMP/htdocs
 
-## (For Drupal multisite) Specify the name of the Drupal site.
-##
-## If the configuration files live under $WEB_ROOT/sites/default,
-## then leave this alone. If the configuration files live under
-## $WEB_ROOT/sites/test.localhost, then set:
-# DRUPAL_SITE=test.localhost
-
 ## The MySQL database used by your pre-existing CiviCRM install.
 ##
 ## The database should already be configured for use with


### PR DESCRIPTION
@seamuslee001 Recall that drush is outputting extra warnings on some versions of PHP, which leads to false-negatives. This should clear that up.

This switches from drush/wp-cli to cv. This simplifies the code in `civicrm-upgrade-test` a bit and improves compatibility with other CMSs.

I tested locally with various permutations of:

* `dmaster`, `bcmaster`, `wpmaster`
* `php72` (*which has been failing on D7*) and `php74` (*which has been passing*)
* Upgrade from DB snapshots for `5.27.*` and `5.33.*`
* Successful upgrades and erroneous upgrades. To provoke errors, hack the `CRM/Upgrade/Incremental/php/*` scripts to include each of these:
    * Throw an exception during an upgrade step
    * Call a non-existent/mis-named function during an upgrade step
    * Log a message with `Civi::log()->error(...)`