### PR TITLE
civicrm-upgrade-examples - Add options to list all metadata as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ number. For example:
 
 ```bash
 mysqldump my_civi_db | bzip2 > databases/4.2.3-my_civi_db.sql.bz2
+./scripts/update-json.php
 ```
 
 This is not strictly required. If you want to create private test-cases,

--- a/bin/civicrm-upgrade-examples
+++ b/bin/civicrm-upgrade-examples
@@ -26,7 +26,7 @@ function help($error = NULL) {
   if ($error) {
     fwrite(STDERR, $error);
   }
-  echo "usage: $prog [--snapshot-library <folder>] [--json] <fileExpr> ...\n";
+  echo "usage: $prog [--snapshot-library <folder>] [--json] [--all | <fileExpr>...]\n";
   echo "\n";
   echo "<fileExpr> examples:\n";
   echo "  /var/foo.sql.gz  A specific file\n";
@@ -49,6 +49,7 @@ function main($args) {
   // default value. may be overridden by a --snapshot-library arg
   $snapshotLibrary = 'databases';
   $printer = 'print_text';
+  $projectDir = dirname(__DIR__);
 
   while (!empty($args)) {
     $arg = array_shift($args);
@@ -58,6 +59,12 @@ function main($args) {
     }
     elseif ($arg === '--json') {
        $printer = 'print_json';
+    }
+    elseif($arg === '--all') {
+      $files = array_merge(
+        $files,
+        (array) glob("$projectDir/databases*/*.bz2"),
+      );
     }
     elseif ($arg[0] === '-') {
       help("Unrecognized option: $arg\n");

--- a/bin/civicrm-upgrade-examples
+++ b/bin/civicrm-upgrade-examples
@@ -19,8 +19,6 @@ if (!$found) {
   die("Failed to find autoloader");
 }
 
-main($argv);
-
 function help($error = NULL) {
   global $argv;
   $prog = basename($argv[0]);
@@ -28,7 +26,7 @@ function help($error = NULL) {
   if ($error) {
     fwrite(STDERR, $error);
   }
-  echo "usage: $prog (--snapshot-library <folder>) <fileExpr> ...\n";
+  echo "usage: $prog [--snapshot-library <folder>] [--json] <fileExpr> ...\n";
   echo "\n";
   echo "<fileExpr> examples:\n";
   echo "  /var/foo.sql.gz  A specific file\n";
@@ -50,12 +48,16 @@ function main($args) {
   $searchArgs = [];
   // default value. may be overridden by a --snapshot-library arg
   $snapshotLibrary = 'databases';
+  $printer = 'print_text';
 
   while (!empty($args)) {
     $arg = array_shift($args);
 
     if ($arg === '--snapshot-library') {
         $snapshotLibrary = array_shift($args);
+    }
+    elseif ($arg === '--json') {
+       $printer = 'print_json';
     }
     elseif ($arg[0] === '-') {
       help("Unrecognized option: $arg\n");
@@ -83,7 +85,30 @@ function main($args) {
   }
 
   $files = $examples->sortFilesByVer(array_unique($files));
+  call_user_func(__NAMESPACE__ . '\\' . $printer, $files);
+}
+
+function get_metadata() {
+  $project = dirname(__DIR__);
+  $file = "$project/databases.json";
+  return json_decode(file_get_contents($file), TRUE);
+}
+
+function print_json($files) {
+  $metadata = get_metadata();
+  $records = [];
+  foreach ($files as $f) {
+    $id = basename(dirname($f)) . '/' . basename($f);
+    $record = $metadata[$id] ?? [];
+    $records[$id] = ['path' => $f] + $record;
+  }
+  echo json_encode($records, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+}
+
+function print_text($files) {
   foreach ($files as $file) {
     echo "$file\n";
   }
 }
+
+main($argv);

--- a/databases.json
+++ b/databases.json
@@ -1,0 +1,298 @@
+{
+    "databases/4.0.0-setupsh.sql.bz2": {
+        "set": "databases",
+        "name": "4.0.0-setupsh",
+        "civicrm": "4.0.0",
+        "mysql": "5.5.25",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/4.0.8-setupsh.sql.bz2": {
+        "set": "databases",
+        "name": "4.0.8-setupsh",
+        "civicrm": "4.0.8",
+        "mysql": "5.5.25",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/4.1.0-setupsh.sql.bz2": {
+        "set": "databases",
+        "name": "4.1.0-setupsh",
+        "civicrm": "4.1.0",
+        "mysql": "5.5.25",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/4.1.6-setupsh.sql.bz2": {
+        "set": "databases",
+        "name": "4.1.6-setupsh",
+        "civicrm": "4.1.6",
+        "mysql": "5.5.25",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/4.2.0-setupsh.sql.bz2": {
+        "set": "databases",
+        "name": "4.2.0-setupsh",
+        "civicrm": "4.2.0",
+        "mysql": "5.5.25",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/4.2.16-setupsh.sql.bz2": {
+        "set": "databases",
+        "name": "4.2.16-setupsh",
+        "civicrm": "4.2.16",
+        "mysql": "5.1.66",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/4.2.9-multilingual_af_bg_en.mysql.bz2": {
+        "set": "databases",
+        "name": "4.2.9-multilingual_af_bg_en",
+        "civicrm": "4.2.9",
+        "mysql": "5.1.41",
+        "uf": "Drupal",
+        "keyword": "multilingual_af_bg_en"
+    },
+    "databases/4.2.9-setupsh.sql.bz2": {
+        "set": "databases",
+        "name": "4.2.9-setupsh",
+        "civicrm": "4.2.9",
+        "mysql": "5.5.25",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/4.3.0-setupsh.sql.bz2": {
+        "set": "databases",
+        "name": "4.3.0-setupsh",
+        "civicrm": "4.3.0",
+        "mysql": "5.5.25",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/4.4.0-setupsh.sql.bz2": {
+        "set": "databases",
+        "name": "4.4.0-setupsh",
+        "civicrm": "4.4.0",
+        "mysql": "5.5.25",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/4.4.5-setupsh.sql.bz2": {
+        "set": "databases",
+        "name": "4.4.5-setupsh",
+        "civicrm": "4.4.5",
+        "mysql": "5.1.66",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/4.5.0-setupsh.sql.bz2": {
+        "set": "databases",
+        "name": "4.5.0-setupsh",
+        "civicrm": "4.5.0",
+        "mysql": "5.5.34",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/4.5.5-setupsh.sql.bz2": {
+        "set": "databases",
+        "name": "4.5.5-setupsh",
+        "civicrm": "4.5.5",
+        "mysql": "5.5.34",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/4.6.0-setupsh.sql.bz2": {
+        "set": "databases",
+        "name": "4.6.0-setupsh",
+        "civicrm": "4.6.0",
+        "mysql": "5.5.42",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/4.6.11-setupsh.sql.bz2": {
+        "set": "databases",
+        "name": "4.6.11-setupsh",
+        "civicrm": "4.6.11",
+        "mysql": "5.5.42",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/4.6.36-setupsh.sql.bz2": {
+        "set": "databases",
+        "name": "4.6.36-setupsh",
+        "civicrm": "4.6.36",
+        "mysql": "5.5.58",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/4.7.0-setupsh.sql.bz2": {
+        "set": "databases",
+        "name": "4.7.0-setupsh",
+        "civicrm": "4.7.0",
+        "mysql": "5.5.42",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/4.7.31-setupsh.sql.bz2": {
+        "set": "databases",
+        "name": "4.7.31-setupsh",
+        "civicrm": "4.7.31",
+        "mysql": "5.5.58",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/5.13.3-multilingual_af_bg_en.mysql.bz2": {
+        "set": "databases",
+        "name": "5.13.3-multilingual_af_bg_en",
+        "civicrm": "5.13.3",
+        "mysql": "5.7.30",
+        "uf": "Drupal",
+        "keyword": "multilingual_af_bg_en"
+    },
+    "databases/5.13.5-setupsh.mysql.bz2": {
+        "set": "databases",
+        "name": "5.13.5-setupsh",
+        "civicrm": "5.13.5",
+        "mysql": "5.6.47",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/5.21.2-setupsh.mysql.bz2": {
+        "set": "databases",
+        "name": "5.21.2-setupsh",
+        "civicrm": "5.21.2",
+        "mysql": "5.6.47",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/5.27.4-setupsh.mysql.bz2": {
+        "set": "databases",
+        "name": "5.27.4-setupsh",
+        "civicrm": "5.27.4",
+        "mysql": "5.6.47",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/5.33.2-setupsh.mysql.bz2": {
+        "set": "databases",
+        "name": "5.33.2-setupsh",
+        "civicrm": "5.33.2",
+        "mysql": "5.6.47",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/5.39.1-setupsh.mysql.bz2": {
+        "set": "databases",
+        "name": "5.39.1-setupsh",
+        "civicrm": "5.39.1",
+        "mysql": "5.6.47",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/5.45.3-setupsh.mysql.bz2": {
+        "set": "databases",
+        "name": "5.45.3-setupsh",
+        "civicrm": "5.45.3",
+        "mysql": "5.6.47",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/5.47.2-tz.mysql.bz2": {
+        "set": "databases",
+        "name": "5.47.2-tz",
+        "civicrm": "5.47.2",
+        "mysql": "5.6.47",
+        "uf": "Drupal",
+        "keyword": "tz"
+    },
+    "databases/5.69.5-big.mysql.bz2": {
+        "set": "databases",
+        "name": "5.69.5-big",
+        "civicrm": "5.69.5",
+        "mysql": "5.7.37",
+        "uf": "Drupal",
+        "keyword": "big"
+    },
+    "databases/5.69.5-default.mysql.bz2": {
+        "set": "databases",
+        "name": "5.69.5-default",
+        "civicrm": "5.69.5",
+        "mysql": "5.7.37",
+        "uf": "Drupal",
+        "keyword": "default"
+    },
+    "databases/5.69.5-small.mysql.bz2": {
+        "set": "databases",
+        "name": "5.69.5-small",
+        "civicrm": "5.69.5",
+        "mysql": "5.7.37",
+        "uf": "Drupal",
+        "keyword": "small"
+    },
+    "databases/5.7.3-setupsh.mysql.bz2": {
+        "set": "databases",
+        "name": "5.7.3-setupsh",
+        "civicrm": "5.7.3",
+        "mysql": "5.6.47",
+        "uf": "Drupal",
+        "keyword": "setupsh"
+    },
+    "databases/5.75.2-big.mysql.bz2": {
+        "set": "databases",
+        "name": "5.75.2-big",
+        "civicrm": "5.75.2",
+        "mysql": "5.7.37",
+        "uf": "Drupal",
+        "keyword": "big"
+    },
+    "databases/5.75.2-default.mysql.bz2": {
+        "set": "databases",
+        "name": "5.75.2-default",
+        "civicrm": "5.75.2",
+        "mysql": "5.7.37",
+        "uf": "Drupal",
+        "keyword": "default"
+    },
+    "databases/5.75.2-small.mysql.bz2": {
+        "set": "databases",
+        "name": "5.75.2-small",
+        "civicrm": "5.75.2",
+        "mysql": "5.7.37",
+        "uf": "Drupal",
+        "keyword": "small"
+    },
+    "databases/5.81.2-big.mysql.bz2": {
+        "set": "databases",
+        "name": "5.81.2-big",
+        "civicrm": "5.81.2",
+        "mysql": "5.7.37",
+        "uf": "Drupal",
+        "keyword": "big"
+    },
+    "databases/5.81.2-default.mysql.bz2": {
+        "set": "databases",
+        "name": "5.81.2-default",
+        "civicrm": "5.81.2",
+        "mysql": "5.7.37",
+        "uf": "Drupal",
+        "keyword": "default"
+    },
+    "databases/5.81.2-small.mysql.bz2": {
+        "set": "databases",
+        "name": "5.81.2-small",
+        "civicrm": "5.81.2",
+        "mysql": "5.7.37",
+        "uf": "Drupal",
+        "keyword": "small"
+    },
+    "databases_standalone/5.77.0-standalone-clean-mysql57.mysql.bz2": {
+        "set": "databases_standalone",
+        "name": "5.77.0-standalone-clean-mysql57",
+        "civicrm": "5.77.0",
+        "mysql": "5.7.37",
+        "uf": "Standalone",
+        "keyword": "standalone-clean-mysql57"
+    }
+}

--- a/scripts/update-json.php
+++ b/scripts/update-json.php
@@ -1,0 +1,55 @@
+#!/usr/bin/env php
+<?php
+/**
+ * @file
+ *
+ * Scan the `./databases*` folders for new database snapshots.
+ * Extract information (such as MySQL version) and store it in `databases.json`.
+ */
+if (PHP_SAPI !== 'cli') {
+  die("update-json.php can only be run from command line.");
+}
+
+$project = dirname(__DIR__);
+$files = glob("$project/database*/*sql*z*");
+$metadataFile = "$project/databases.json";
+
+$oldRecords = file_exists($metadataFile)
+  ? json_decode(file_get_contents($metadataFile), TRUE)
+  : [];
+
+$newRecords = $oldRecords;
+foreach ($files as $f) {
+  $id = basename(dirname($f)) . '/' . basename($f);
+  if (isset($oldRecords[$id])) {
+    continue;
+  }
+
+  printf("Found %s\n", $id);
+
+  $cmd = sprintf('bzcat %s | grep -e "-- MySQL dump" | cut -f7 -d\ ', escapeshellarg($f));
+  printf("Inspect %s\n", $cmd);
+  $mysqlVer = trim(`$cmd`, " \r\n\t,");
+  #$mysqlVer = $cmd;
+
+  preg_match('/^(([\d\.]+)-([-\w]+))\.(my)?sql/', basename($f), $m);
+  $newRecords[$id] = [
+    'set' => basename(dirname($f)),
+    'name' => $m[1] ?? NULL,
+    'civicrm' => $m[2] ?? NULL,
+    'mysql' => $mysqlVer,
+    'uf' => preg_match(';standalone;', basename(dirname($f))) ? 'Standalone' : 'Drupal',
+    // FIXME: It sould be better to get UF from data. But in practice, everything in 'databases/*' did from D7...
+    'keyword' => $m[3] ?? NULL,
+  ];
+}
+
+ksort($newRecords);
+if ($newRecords == $oldRecords) {
+  echo "No changes\n";
+}
+else {
+  echo "Update $metadataFile\n";
+  $json = json_encode($newRecords, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+  file_put_contents($metadataFile, $json);
+}


### PR DESCRIPTION
This is technically a few things:

* `civicrm-upgrade-examples --json`: Print the list of examples with extended metadata (JSON), including the CiviCRM version, MySQL version, and UF type.
* `civicrm-upgrade-examples --all`: Print all known examples, without any kind of filtering